### PR TITLE
#39 검색/페이지네이션 정합성 통일

### DIFF
--- a/src/main/java/com/gdg/backend/api/goal/controller/GoalController.java
+++ b/src/main/java/com/gdg/backend/api/goal/controller/GoalController.java
@@ -60,9 +60,14 @@ public class GoalController {
     @GetMapping("/lists")
     public ResponseEntity<ApiResponse<Page<GoalListResponseDto>>> getGoals(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestParam(defaultValue = "0") @Min(0) int page
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "3") @Min(1) int size,
+            @RequestParam(required = false) String search
     ){
-        return ApiResponse.success(SuccessCode.GOAL_LIST_SUCCESS,goalService.getGoals(userPrincipal.userId(), page));
+        return ApiResponse.success(
+                SuccessCode.GOAL_LIST_SUCCESS,
+                goalService.getGoals(userPrincipal.userId(), page, size, search)
+        );
     }
 
     @Operation(

--- a/src/main/java/com/gdg/backend/api/goal/repository/GoalRepository.java
+++ b/src/main/java/com/gdg/backend/api/goal/repository/GoalRepository.java
@@ -4,10 +4,41 @@ import com.gdg.backend.api.goal.domain.Goal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface GoalRepository extends JpaRepository<Goal, Long> {
-    Page<Goal> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    @Query(
+            value = """
+                    select distinct g
+                    from Goal g
+                    left join g.tasks t
+                    where g.user.id = :userId
+                      and (
+                        :keyword is null
+                        or lower(g.title) like lower(concat('%', :keyword, '%'))
+                        or lower(t.content) like lower(concat('%', :keyword, '%'))
+                      )
+                    """,
+            countQuery = """
+                    select count(distinct g)
+                    from Goal g
+                    left join g.tasks t
+                    where g.user.id = :userId
+                      and (
+                        :keyword is null
+                        or lower(g.title) like lower(concat('%', :keyword, '%'))
+                        or lower(t.content) like lower(concat('%', :keyword, '%'))
+                      )
+                    """
+    )
+    Page<Goal> searchGoals(
+            @Param("userId") Long userId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
     Optional<Goal> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/gdg/backend/api/goal/service/GoalService.java
+++ b/src/main/java/com/gdg/backend/api/goal/service/GoalService.java
@@ -32,8 +32,6 @@ public class GoalService {
     private final UserRepository userRepository;
     private final TaskRepository taskRepository;
 
-    private static final int PAGE_SIZE = 3;
-
     //목표
     @Transactional
     public CreateGoalResponseDto createGoal(Long userId, CreateGoalRequestDto req) {
@@ -48,10 +46,16 @@ public class GoalService {
     }
 
     @Transactional(readOnly = true)
-    public Page<GoalListResponseDto> getGoals(Long userId, int page) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+    public Page<GoalListResponseDto> getGoals(Long userId, int page, int size, String search) {
+        String searchTerm = resolveSearchTerm(search);
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+                        .and(Sort.by(Sort.Direction.DESC, "id"))
+        );
 
-        return goalRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable)
+        return goalRepository.searchGoals(userId, searchTerm, pageable)
                 .map(GoalListResponseDto::from);
     }
 
@@ -110,5 +114,13 @@ public class GoalService {
         }
 
         taskRepository.delete(task);
+    }
+
+    private String resolveSearchTerm(String search) {
+        if (search == null) {
+            return null;
+        }
+        String term = search.trim();
+        return term.isEmpty() ? null : term;
     }
 }

--- a/src/main/java/com/gdg/backend/api/record/controller/RecordController.java
+++ b/src/main/java/com/gdg/backend/api/record/controller/RecordController.java
@@ -5,7 +5,7 @@ import com.gdg.backend.api.record.domain.Category;
 import com.gdg.backend.api.record.dto.CreateRecordRequestDto;
 import com.gdg.backend.api.record.dto.CreateRecordResponseDto;
 import com.gdg.backend.api.record.dto.RecordDetailResponseDto;
-import com.gdg.backend.api.record.dto.RecordListResponseDto;
+import com.gdg.backend.api.record.dto.RecordListPageResponseDto;
 import com.gdg.backend.api.record.dto.UpdateRecordDetailRequestDto;
 import com.gdg.backend.api.record.dto.UpdateRecordDetailResponseDto;
 import com.gdg.backend.api.record.service.RecordService;
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -57,11 +56,13 @@ public class RecordController {
             description = "학습 기록을 전체 또는 카테고리별로 페이지 단위 조회합니다."
     )
     @GetMapping("/lists")
-    public ResponseEntity<ApiResponse<Page<RecordListResponseDto>>> getMyRecords(
+    public ResponseEntity<ApiResponse<RecordListPageResponseDto>> getMyRecords(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(defaultValue = "1") @Min(1) int page,
             @RequestParam(defaultValue = "4") @Min(1) int size,
-            @RequestParam(required = false) String category
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String keyword
     ) {
         Category parsedCategory = null;
         if (category != null && !category.isBlank()) {
@@ -72,7 +73,7 @@ public class RecordController {
 
         return ApiResponse.success(
                 SuccessCode.RECORD_LIST_SUCCESS,
-                recordService.getMyRecords(userPrincipal.userId(), zeroBasedPage, size, parsedCategory)
+                recordService.getMyRecords(userPrincipal.userId(), zeroBasedPage, size, parsedCategory, search, keyword)
         );
     }
 

--- a/src/main/java/com/gdg/backend/api/record/dto/RecordListPageResponseDto.java
+++ b/src/main/java/com/gdg/backend/api/record/dto/RecordListPageResponseDto.java
@@ -1,0 +1,19 @@
+package com.gdg.backend.api.record.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class RecordListPageResponseDto {
+
+    private final List<RecordListResponseDto> items;
+    private final int page;
+    private final int size;
+    private final int totalPages;
+    private final long totalElements;
+    private final boolean hasNext;
+    private final boolean hasPrev;
+}

--- a/src/main/java/com/gdg/backend/api/record/repository/RecordRepository.java
+++ b/src/main/java/com/gdg/backend/api/record/repository/RecordRepository.java
@@ -29,7 +29,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
                       and (
                         :keyword is null
                         or lower(r.title) like lower(concat('%', :keyword, '%'))
-                        or lower(r.content) like lower(concat('%', :keyword, '%'))
+                        or lower(cast(r.content as string)) like lower(concat('%', :keyword, '%'))
                         or lower(k.name) like lower(concat('%', :keyword, '%'))
                       )
                     """,
@@ -42,7 +42,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
                       and (
                         :keyword is null
                         or lower(r.title) like lower(concat('%', :keyword, '%'))
-                        or lower(r.content) like lower(concat('%', :keyword, '%'))
+                        or lower(cast(r.content as string)) like lower(concat('%', :keyword, '%'))
                         or lower(k.name) like lower(concat('%', :keyword, '%'))
                       )
                     """

--- a/src/main/java/com/gdg/backend/api/record/repository/RecordRepository.java
+++ b/src/main/java/com/gdg/backend/api/record/repository/RecordRepository.java
@@ -19,6 +19,41 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
     Page<Record> findByUserIdAndCategory(Long userId, Category category, Pageable pageable);
 
+    @Query(
+            value = """
+                    select distinct r
+                    from Record r
+                    left join r.keywords k
+                    where r.user.id = :userId
+                      and (:category is null or r.category = :category)
+                      and (
+                        :keyword is null
+                        or lower(r.title) like lower(concat('%', :keyword, '%'))
+                        or lower(r.content) like lower(concat('%', :keyword, '%'))
+                        or lower(k.name) like lower(concat('%', :keyword, '%'))
+                      )
+                    """,
+            countQuery = """
+                    select count(distinct r)
+                    from Record r
+                    left join r.keywords k
+                    where r.user.id = :userId
+                      and (:category is null or r.category = :category)
+                      and (
+                        :keyword is null
+                        or lower(r.title) like lower(concat('%', :keyword, '%'))
+                        or lower(r.content) like lower(concat('%', :keyword, '%'))
+                        or lower(k.name) like lower(concat('%', :keyword, '%'))
+                      )
+                    """
+    )
+    Page<Record> searchRecords(
+            @Param("userId") Long userId,
+            @Param("category") Category category,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
     Optional<Record> findByIdAndUserId(Long recordId, Long userId);
 
     @Modifying


### PR DESCRIPTION

목적: Records/Goals 검색 + 페이지네이션 정합성 서버 기준 통일

변경점:
- Records: search/keyword 우선순위 적용, 필터→정렬→페이지네이션 순서 보장, 응답 메타 스키마 통일
- Goals: /goals/lists에 search, size 추가 및 검색 필터 적용(목표 제목 + 과제 내용)

영향 범위:
- /record/lists 응답 구조 변경(아이템 + 메타)
- /goals/lists 검색 파라미터 확장
- 테스트/QA 포인트:
- Records: search=1&category=lecture&page=1 결과 노출, keyword 동작 동일, 검색 없음/없음 단어 처리
- Goals: search=리액트 진입 시 페이지 1부터 결과 노출, 페이지 이동 시 누락/중복 없음